### PR TITLE
Rootless Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,6 @@
 # Postfix Testing
-## Setup DKIM
-This will generate the dkim files
-```
-cd ./dkim
-./setup.sh
-```
 
-## Setup StartTLS certs
-This will generate the tls (startssl files)
-```
-cd ./certs
-./setup.sh
-```
+The setup procedure will generate a new public and private keypair for postfix communication and a new dkim keypair (hacking-lab.com) to sign mails.
 
 ## Start the Service
 ```
@@ -33,7 +22,7 @@ docker-compose exec postfix tail -f /var/log/mail.log
 
 ### Postfix will accept this - but GMAIL is not accepting it (mail does not look trustworthy for GMAIL)
 Port 25
-* ./smtptest.py -v -u ivan.buetler -p EBp5CJNcykf7cgmb ibuetler@hsr.ch ivan.buetler@gmail.com localhost$
+* ./smtptest.py -v -u ivan.buetler -p EBp5CJNcykf7cgmb ibuetler@hsr.ch ivan.buetler@gmail.com localhost
 
 Port 587 (Submission)
 * ./smtptest.py -v -n 587 -t -u ivan.buetler -p EBp5CJNcykf7cgmb ibuetler@hsr.ch ivan.buetler@gmail.com localhost

--- a/certs/setup.sh
+++ b/certs/setup.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-openssl req -newkey rsa:4096 -nodes -sha512 -x509 -days 3650 -nodes -out postfix.crt -keyout postfix.key
-
-

--- a/dkim/setup.sh
+++ b/dkim/setup.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-apt-get -y install opendkim opendkim-tools
-opendkim-genkey -s mail -d hacking-lab.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.6"
 
 services:
   postfix:
-    image: index.docker.io/catatnight/postfix:latest
+    image: catatnight/postfix:latest
     hostname: postfix.localhost
     restart: always
     environment:
@@ -12,8 +12,6 @@ services:
       maildomain: hacking-lab.com
       smtp_user: ivan.buetler:EBp5CJNcykf7cgmb,no-reply:FIj8qVxZXINXjJOC
     volumes:
-      - ./dkim:/etc/opendkim/domainkeys
-      - ./certs:/etc/postfix/certs
       - ./postfix/install.sh:/opt/install.sh
     labels:
       traefik.enable: false

--- a/postfix/install.sh
+++ b/postfix/install.sh
@@ -94,7 +94,7 @@ fi
 
 mkdir -p /etc/opendkim/domainkeys
 chown opendkim:opendkim /etc/opendkim/domainkeys
-opendkim-genkey -s mail -d hacking-lab.com --directory=/etc/opendkim/domainkeys
+opendkim-genkey -s mail -d $maildomain --directory=/etc/opendkim/domainkeys
 
 if [[ -z "$(find /etc/opendkim/domainkeys -iname *.private)" ]]; then
   echo "opendkim is not configured"

--- a/postfix/install.sh
+++ b/postfix/install.sh
@@ -66,42 +66,37 @@ chown postfix.sasl /etc/sasldb2
 # Enable TLS
 ############
 
+echo "configuring ssl certs and keys"
+
 mkdir -p /etc/postfix/certs
 openssl req -newkey rsa:4096 -nodes -sha512 -x509 -days 3650 -subj "/C=CH/ST=SG/L=HL/O=HL/CN=postfix.local/emailAddress=postfix@localhost" \
   -out /etc/postfix/certs/postfix.crt \
   -keyout /etc/postfix/certs/postfix.key
 
-if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && -n "$(find /etc/postfix/certs -iname *.key)" ]]; then
-  echo "configuring ssl certs and keys"
-  # /etc/postfix/main.cf
-  postconf -e smtpd_tls_cert_file=$(find /etc/postfix/certs -iname *.crt)
-  postconf -e smtpd_tls_key_file=$(find /etc/postfix/certs -iname *.key)
-  chmod 400 /etc/postfix/certs/*.*
-  echo "listing of tls certs and keys"
-  ls -al /etc/postfix/certs/
-  # /etc/postfix/master.cf
-  postconf -M submission/inet="submission   inet   n   -   n   -   -   smtpd"
-  postconf -P "submission/inet/syslog_name=postfix/submission"
-  postconf -P "submission/inet/smtpd_tls_security_level=encrypt"
-  postconf -P "submission/inet/smtpd_sasl_auth_enable=yes"
-  postconf -P "submission/inet/milter_macro_daemon_name=ORIGINATING"
-  postconf -P "submission/inet/smtpd_recipient_restrictions=permit_sasl_authenticated,reject_unauth_destination"
-fi
+# /etc/postfix/main.cf
+postconf -e smtpd_tls_cert_file=$(find /etc/postfix/certs -iname *.crt)
+postconf -e smtpd_tls_key_file=$(find /etc/postfix/certs -iname *.key)
+chmod 400 /etc/postfix/certs/*.*
+echo "listing of tls certs and keys"
+ls -al /etc/postfix/certs/
+# /etc/postfix/master.cf
+postconf -M submission/inet="submission   inet   n   -   n   -   -   smtpd"
+postconf -P "submission/inet/syslog_name=postfix/submission"
+postconf -P "submission/inet/smtpd_tls_security_level=encrypt"
+postconf -P "submission/inet/smtpd_sasl_auth_enable=yes"
+postconf -P "submission/inet/milter_macro_daemon_name=ORIGINATING"
+postconf -P "submission/inet/smtpd_recipient_restrictions=permit_sasl_authenticated,reject_unauth_destination"
 
 #############
 #  opendkim
 #############
 
+echo "configuring opendkim"
+
 mkdir -p /etc/opendkim/domainkeys
 chown opendkim:opendkim /etc/opendkim/domainkeys
 opendkim-genkey -s mail -d $maildomain --directory=/etc/opendkim/domainkeys
 
-if [[ -z "$(find /etc/opendkim/domainkeys -iname *.private)" ]]; then
-  echo "opendkim is not configured"
-  exit 0
-fi
-
-echo "configuring opendkim"
 cat >> /etc/supervisor/conf.d/supervisord.conf <<EOF
 
 [program:opendkim]

--- a/postfix/install.sh
+++ b/postfix/install.sh
@@ -65,6 +65,12 @@ chown postfix.sasl /etc/sasldb2
 ############
 # Enable TLS
 ############
+
+mkdir -p /etc/postfix/certs
+openssl req -newkey rsa:4096 -nodes -sha512 -x509 -days 3650 -subj "/C=CH/ST=SG/L=HL/O=HL/CN=postfix.local/emailAddress=postfix@localhost" \
+  -out /etc/postfix/certs/postfix.crt \
+  -keyout /etc/postfix/certs/postfix.key
+
 if [[ -n "$(find /etc/postfix/certs -iname *.crt)" && -n "$(find /etc/postfix/certs -iname *.key)" ]]; then
   echo "configuring ssl certs and keys"
   # /etc/postfix/main.cf
@@ -85,6 +91,10 @@ fi
 #############
 #  opendkim
 #############
+
+mkdir -p /etc/opendkim/domainkeys
+chown opendkim:opendkim /etc/opendkim/domainkeys
+opendkim-genkey -s mail -d hacking-lab.com --directory=/etc/opendkim/domainkeys
 
 if [[ -z "$(find /etc/opendkim/domainkeys -iname *.private)" ]]; then
   echo "opendkim is not configured"


### PR DESCRIPTION
Dieses Setup integriert die Schritte für die Erstellung der Zertifikate in das Init-Skript, damit keine Abhängigkeit auf Mounts und zusätzliche Schritte ausserhalb des Containers notwenig sind.

Die DKIM-Keys können nun so eingesehen werden:
```
docker-compose exec postfix cat /etc/opendkim/domainkeys/mail.private
docker-compose exec postfix cat /etc/opendkim/domainkeys/mail.txt
```

Das Keypair für die TLS-Verbindung kann so eingesehen werden:
```
docker-compose exec postfix cat /etc/postfix/certs/postfix.crt
docker-compose exec postfix cat /etc/postfix/certs/postfix.key  
```